### PR TITLE
fix(GH): bump docs mermaid to 11.16.1 for Trivy CVEs

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9,7 +9,7 @@
         "@muenchen/prettier-codeformat": "1.0.2",
         "esbuild": "0.28.1",
         "markdown-it": "14.3.0",
-        "mermaid": "11.16.0",
+        "mermaid": "11.16.1",
         "prettier": "3.9.6",
         "vitepress": "1.6.4"
       },
@@ -3098,8 +3098,8 @@
       "license": "MIT"
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.16.1",
+      "integrity": "sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -19,7 +19,7 @@
     "@muenchen/prettier-codeformat": "1.0.2",
     "esbuild": "0.28.1",
     "markdown-it": "14.3.0",
-    "mermaid": "11.16.0",
+    "mermaid": "11.16.1",
     "prettier": "3.9.6",
     "vitepress": "1.6.4"
   },


### PR DESCRIPTION
## Summary
- Bump docs `mermaid` `11.16.0` → `11.16.1` to clear Trivy CVEs (CVE-2026-50159, CVE-2026-71436, CVE-2026-71437, CVE-2026-71439, CVE-2026-71438)